### PR TITLE
Fixed proptypes issue on newer versions of React Native

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,

--- a/main.js
+++ b/main.js
@@ -47,7 +47,7 @@ class SubmitButton extends Component {
 
   componentWillReceiveProps(nextProps) {
     const buttonState = nextProps.buttonState;
-    if (buttonState === 'success' || buttonState === 'error') {
+    if ((buttonState === 'success' || buttonState === 'error') && this.props.buttonState !== buttonState) {
       this.setState(
         { isLoading: false, isReady: true, canShowAnimatedCircle: false },
         this.animateBackToOriginal

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "prop-types": "^15.6.0",
     "react-native-circular-progress": "git+https://github.com/bgryszko/react-native-circular-progress.git#85eb3c4d781cd70b281c0ff080cb7639f8a957f4",
-    "react-native-vector-icons": "3.0.0"
+    "react-native-vector-icons": "^4.4.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-native-circular-progress": "0.0.8",
+    "react-native-circular-progress": "git+https://github.com/bgryszko/react-native-circular-progress.git#85eb3c4d781cd70b281c0ff080cb7639f8a957f4",
     "react-native-vector-icons": "3.0.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-native-circular-progress": "0.0.8",
     "react-native-vector-icons": "3.0.0"
   },


### PR DESCRIPTION
On new versions of react-native, prop-types is a seperate package. As such, this package does not work. This pull request fixes that by adding the seperate package and fixing imports.

Other packages also contain the same issue, however they need to be updated seperately.